### PR TITLE
Remove duplicated entry for rust.vim

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -74,7 +74,6 @@ Plug 'dag/vim2hs'
 Plug 'prabirshrestha/async.vim'
 " Plug 'prabirshrestha/vim-lsp'
 Plug 'gluon-lang/vim-gluon'
-Plug 'rust-lang/rust.vim'
 "Plugin 'phildawes/racer'
 "
 Plug 'autozimu/LanguageClient-neovim', { 'do': ':UpdateRemotePlugins' }


### PR DESCRIPTION
Hi,

I just noticed, It seems that you have `rust-lang/rust.vim` line in **init.vim**, twice ([L.72](https://github.com/Marwes/vim-config/blob/master/init.vim#L72) and [L.77](https://github.com/Marwes/vim-config/blob/master/init.vim#L77) on master)

;-)